### PR TITLE
169 fix failing redactions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 
  - Dropped support for Python 3.7 and 3.8
  - Upgrade dependencies.
+ - Fix for bug that may cause crosshatched redactions to fail
 
 
 ## Current Version

--- a/README.md
+++ b/README.md
@@ -154,6 +154,11 @@ The PDF format is a big and complicated one, so it's difficult to do all this pe
 
 [d]: https://free.law/donate/
 
+## Testing
+
+To run all tests use the following command. Be aware there is one failing test that is marked as failing. 
+
+ `python3 -m unittest tests/test_utils.py`
 
 ## Contributions
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -230,6 +230,15 @@ class InspectApiTest(TestCase):
         redactions = xray.inspect(data)
         self.assertTrue(redactions)
 
+    def test_inspect_works_with_crosshatch(self):
+        """Test gray scaled redactions"""
+        path = root_path / "bad_cross_hatched_redactions.pdf"
+        with open(path, "rb") as f:
+            data = f.read()
+
+        redactions = xray.inspect(data)
+        self.assertTrue(redactions)
+
 
 class IntegrationTest(TestCase):
     """Do our highest-level APIs work?"""


### PR DESCRIPTION
Cross Hatch [XXXX] style redactions always fail because we require redactions to be one solid color.

This PR replaces that check with a more nuanced check of a block.  It uses adaptive thresholding to 
determine if a pixel is white or black and then determines if the redaction is a solid color.  

Additionally, updates the readme around testing and adds a test for our Cross Hatch example