### PR TITLE
feat(types): Add BadRedactionType enum to output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@
  - Fix truncated date fragments (e.g., "03/23/") not being recognized as dates ([issue](https://github.com/freelawproject/x-ray/issues/30))
  - Detect dark images used as redaction overlays (ignores images drawn behind text)
  - Detect PDF bookmarks/TOC entries that leak redacted heading content ([issue](https://github.com/freelawproject/x-ray/issues/2))
+ - Add `type` field to redaction output with `BadRedactionType` enum
 
 ## Current Version
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Once you *do* install x-ray, you can easily use it on the command line. Once ins
         75.65007781982422,
         739.3987426757812
       ],
-      "text": "The Ring travels by way of Cirith Ungol"
+      "text": "The Ring travels by way of Cirith Ungol",
+      "type": "TEXT_UNDER_RECTANGLE"
     }
   ]
 }
@@ -85,11 +86,21 @@ However you run `xray` on the command line, you'll get JSON as output. When you 
  - It's a dict.
  - The keys are page numbers.
  - Each page number maps to a list of dicts.
- - Each of those dicts maps to two keys.
- - The first key is `bbox`. This is a four-tuple that indicates the x,y positions of the upper left corner and then lower right corners of the bad redaction.
- - The second key is `text`. This is the text under the bad rectangle.
+ - Each of those dicts maps to three keys.
+ - `bbox` — A four-tuple with the x,y positions of the upper left and lower right corners of the bad redaction.
+ - `text` — The text under the bad rectangle.
+ - `type` — The type of bad redaction detected. One of the values below.
 
-Simple enough.
+### Detection types
+
+| Type | Description |
+|------|-------------|
+| `TEXT_UNDER_RECTANGLE` | Text hidden under a dark vector rectangle. The classic bad redaction — someone drew a black box on top of text without removing it from the PDF. |
+| `UNAPPLIED_REDACT_ANNOTATION` | A PDF Redact annotation was added but never applied. The annotation marks text for redaction but the text is still visible and extractable. |
+| `DARK_HIGHLIGHT_ANNOTATION` | A dark (usually black) Highlight annotation covers text. Highlights are meant for markup, not redaction — the text remains fully readable. |
+| `CROSS_HATCHED_PATTERN` | Text hidden under a cross-hatched (X-pattern) overlay. These repeating diagonal line patterns are drawn over dark rectangles as a visual redaction style. |
+| `TEXT_UNDER_IMAGE` | Text hidden under a dark raster image. Instead of using a vector rectangle, someone pasted a solid black image on top of the text. |
+| `TOC_BOOKMARK_LEAK` | A PDF bookmark/TOC entry reveals text that was redacted on the page. The heading was properly redacted but the bookmark still contains the original text. |
 
 You can also use it as a Python module, if you prefer the long-form:
 
@@ -147,21 +158,28 @@ find out.
 
 Under the covers, `xray` uses the high-performant [PyMuPDF project][mu] to parse PDFs. It has been a wonderful project to work with.
 
-You can read the source to see how it works, but the general idea is to:
+You can read the source to see how it works, but the general idea is:
 
-1. Find rectangles in a PDF.
+1. **Rectangles** — Find dark vector rectangles (including rounded ones drawn
+   with curves), check if there's extractable text underneath, and render the
+   area as a pixmap to confirm the text is actually hidden.
 
-2. Find letters in the same location
+2. **Annotations** — Detect unapplied Redact annotations (marked but never
+   applied) and dark Highlight annotations used as makeshift redactions.
 
-3. Render the rectangle as an image
+3. **Patterns** — Detect cross-hatched (X-pattern) overlays by examining the
+   PDF drawing structure for repeating diagonal line pairs.
 
-4. Inspect the rectangle to see if it's all one color. If it is, then that's a
-   bad redaction. If not, then we assume you can see a mix of text and
-   drawings, indicating a redaction that's OK.
+4. **Images** — Detect solid dark raster images placed over text by rendering
+   the page at each image location to confirm the area is dark.
 
-5. Filter out common false positives: single characters, repeated characters
-   (like "XXXX"), whitespace, known boilerplate words (like "REDACTED"),
-   and white-on-white rectangles.
+5. **TOC leaks** — Check PDF bookmarks for entries that reveal text redacted on
+   the referenced page.
+
+6. **False positive filtering** — Filter out single characters, repeated
+   characters (like "XXXX"), whitespace, known boilerplate words (like
+   "REDACTED"), white-on-white rectangles, bright-colored design elements,
+   CM/ECF court header stamps, and garbled text from custom font encodings.
 
 The PDF format is a big and complicated one, so it's difficult to do all this perfectly. We do our best, but there's always more to do to make it better. [Donations][d] and sponsored work help.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ import fitz
 from fitz import Rect
 
 import xray
+from xray.custom_types import BadRedactionType
 from xray.pdf_utils import (
     get_bad_redactions,
     get_content_spans,
@@ -265,6 +266,9 @@ class IntegrationTest(TestCase):
     def test_inspect_method_on_a_filepath(self):
         redactions = xray.inspect(self.path)
         self.assertEqual(len(redactions[1]), 3)
+        # All redactions in this file are text under rectangles
+        for r in redactions[1]:
+            self.assertEqual(r["type"], BadRedactionType.TEXT_UNDER_RECTANGLE)
 
     def test_tricky_rectangles(self):
         """Check that tricky PDFs don't create false positives.
@@ -488,6 +492,12 @@ class IntegrationTest(TestCase):
 
         # Page 1: applied redaction — TOC leaks the name
         self.assertIn("Report by John Smith", all_texts.get(1, []))
+        toc_leak = [
+            r
+            for r in redactions.get(1, [])
+            if r["text"] == "Report by John Smith"
+        ][0]
+        self.assertEqual(toc_leak["type"], BadRedactionType.TOC_BOOKMARK_LEAK)
 
         # Page 2: bad redaction — text still extractable
         self.assertTrue(

--- a/xray/custom_types.py
+++ b/xray/custom_types.py
@@ -1,8 +1,24 @@
 """Custom types for MyPy"""
 
+from enum import Enum
 from typing import TypedDict
 
 from fitz import Rect
+
+
+class BadRedactionType(str, Enum):
+    """The type of bad redaction detected.
+
+    Using ``str, Enum`` so values serialize to JSON naturally
+    without a custom encoder.
+    """
+
+    TEXT_UNDER_RECTANGLE = "TEXT_UNDER_RECTANGLE"
+    UNAPPLIED_REDACT_ANNOTATION = "UNAPPLIED_REDACT_ANNOTATION"
+    DARK_HIGHLIGHT_ANNOTATION = "DARK_HIGHLIGHT_ANNOTATION"
+    CROSS_HATCHED_PATTERN = "CROSS_HATCHED_PATTERN"
+    TEXT_UNDER_IMAGE = "TEXT_UNDER_IMAGE"
+    TOC_BOOKMARK_LEAK = "TOC_BOOKMARK_LEAK"
 
 
 class RedactionType(TypedDict):
@@ -10,6 +26,7 @@ class RedactionType(TypedDict):
 
     bbox: tuple[float, ...]
     text: str
+    type: BadRedactionType
 
 
 # The type used for the top-level dictionary of all redactions for a document

--- a/xray/pdf_utils.py
+++ b/xray/pdf_utils.py
@@ -8,7 +8,12 @@ import typing
 import fitz
 from fitz import Page, Rect
 
-from .custom_types import CharDictType, PdfRedactionsDict, RedactionType
+from .custom_types import (
+    BadRedactionType,
+    CharDictType,
+    PdfRedactionsDict,
+    RedactionType,
+)
 from .text_utils import is_ok_words, is_repeated_chars, is_single_char
 
 # Disable anti-aliasing when rendering and creating pixmaps
@@ -282,6 +287,7 @@ def group_chars_by_rect(
         redaction: RedactionType = {
             "bbox": (rect.x0, rect.y0, rect.x1, rect.y1),
             "text": "",
+            "type": BadRedactionType.TEXT_UNDER_RECTANGLE,
         }
         # Make a copy of the chars list so we can manipulate it in the loop
         char_copy = chars.copy()
@@ -502,6 +508,7 @@ def get_unapplied_redact_annotations(page: Page) -> list[RedactionType]:
                     visible_rect.y1,
                 ),
                 "text": text,
+                "type": BadRedactionType.UNAPPLIED_REDACT_ANNOTATION,
             }
             redactions.append(redaction)
 
@@ -552,6 +559,7 @@ def get_dark_highlight_annotations(page: Page) -> list[RedactionType]:
                     visible_rect.y1,
                 ),
                 "text": text,
+                "type": BadRedactionType.DARK_HIGHLIGHT_ANNOTATION,
             }
             redactions.append(redaction)
 
@@ -638,6 +646,7 @@ def get_cross_hatched_redactions(page: Page) -> list[RedactionType]:
             redaction: RedactionType = {
                 "bbox": (xh_rect.x0, xh_rect.y0, xh_rect.x1, xh_rect.y1),
                 "text": text,
+                "type": BadRedactionType.CROSS_HATCHED_PATTERN,
             }
             redactions.append(redaction)
 
@@ -709,6 +718,7 @@ def get_image_redactions(page: Page) -> list[RedactionType]:
             redaction: RedactionType = {
                 "bbox": (bbox.x0, bbox.y0, bbox.x1, bbox.y1),
                 "text": text,
+                "type": BadRedactionType.TEXT_UNDER_IMAGE,
             }
             redactions.append(redaction)
 
@@ -891,6 +901,7 @@ def get_toc_leaks(
         leak: RedactionType = {
             "bbox": (target.x, target.y, target.x, target.y),
             "text": title,
+            "type": BadRedactionType.TOC_BOOKMARK_LEAK,
         }
         redactions.setdefault(page_key, []).append(leak)
 


### PR DESCRIPTION
## Summary
- Add `BadRedactionType` str enum with six detection types
- Add `type` field to `RedactionType` TypedDict and all 6 creation sites
- Values serialize as uppercase strings in JSON (e.g., `"TEXT_UNDER_RECTANGLE"`)

### Detection types

| Type | Description |
|------|-------------|
| `TEXT_UNDER_RECTANGLE` | Text hidden under a dark vector rectangle |
| `UNAPPLIED_REDACT_ANNOTATION` | Redact annotation added but never applied |
| `DARK_HIGHLIGHT_ANNOTATION` | Dark highlight annotation covering text |
| `CROSS_HATCHED_PATTERN` | Cross-hatched (X-pattern) overlay hiding text |
| `TEXT_UNDER_IMAGE` | Dark raster image placed over text |
| `TOC_BOOKMARK_LEAK` | Bookmark reveals text redacted on the page |

### Example output

```json
{
  "1": [
    {
      "bbox": [58.55, 72.20, 75.65, 739.40],
      "text": "The Ring travels by way of Cirith Ungol",
      "type": "TEXT_UNDER_RECTANGLE"
    }
  ]
}
```

## Test plan
- [x] Type assertions on `test_inspect_method_on_a_filepath` (TEXT_UNDER_RECTANGLE)
- [x] Type assertion on `test_toc_leak` (TOC_BOOKMARK_LEAK)
- [x] All 38 tests pass
- [x] mypy and pre-commit pass
- [x] JSON output verified with `python -m xray`
- [ ] Merge after #212 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)