### PR TITLE
correctness(text_utils): correct regex alternation order in is_ok_words

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ way, they just draw a black rectangle or a black highlight on top of black
 text and call it a day. Well, when that happens you just select the text under
 the rectangle, and you can read it again. Not great.
 
-After witnessing this problem for years (our favorite is the doc that shared 
+After witnessing this problem for years (our favorite is the doc that shared
 Taylor Swift's personal phone number), we decided it would be good to do
-something about it. 
+something about it.
 
-This tool is our answer. You give the tool the path to a PDF. It tells you if 
+This tool is our answer. You give the tool the path to a PDF. It tells you if
 it has worthless redactions in it and whether to call Taylor (don't).
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ X-Ray Tests
 """
 
 import os
+import re
 import unittest
 from pathlib import Path
 from unittest import TestCase
@@ -17,7 +18,7 @@ from xray.pdf_utils import (
     get_intersecting_chars,
     intersects,
 )
-from xray.text_utils import looks_like_a_date
+from xray.text_utils import is_ok_words, looks_like_a_date
 
 root_path = Path(__file__).resolve().parent / "assets"
 
@@ -47,6 +48,27 @@ class TextTest(TestCase):
         for d in not_dates:
             with self.subTest(d):
                 self.assertFalse(looks_like_a_date(d))
+
+    def test_is_ok_words_regex_ordering(self):
+        """Short-before-long alternation caused "re" to fire on "redacted".
+
+        Python's re tries alternatives left-to-right; the first match wins.
+        The old pattern listed "re" before "redacted", so at position 0 of
+        "redacted" the engine matched "re", left "dacted" as the remainder,
+        and is_ok_words returned True — a false positive.
+        """
+        old_pattern = (
+            r"confidential|name +redacted|privileged?|re|red|reda|redac|redact|"
+            r"redacte|redacted|redacted +and +publicly +filed|"
+        )
+
+        # old: "re" fires first, leaving a non-empty remainder → false positive
+        self.assertEqual(
+            re.sub(old_pattern, "", "redacted", flags=re.IGNORECASE), "dacted"
+        )
+
+        # fixed: full word matches → correctly filtered
+        self.assertFalse(is_ok_words("redacted"))
 
 
 class RectTest(TestCase):

--- a/xray/text_utils.py
+++ b/xray/text_utils.py
@@ -29,8 +29,8 @@ def is_ok_words(text: str) -> bool:
     """
     text = " ".join(text.strip().split())
     text = re.sub(
-        r"confidential|name +redacted|privileged?|re|red|reda|redac|redact|"
-        r"redacte|redacted|redacted +and +publicly +filed|",
+        r"confidential|name +redacted|redacted +and +publicly +filed|"
+        r"redacted|redacte|redact|redac|reda|red|re|privileged?",
         "",
         text,
         flags=re.IGNORECASE | re.MULTILINE,


### PR DESCRIPTION
`is_ok_words` used a regex where short prefixes like `re` appeared before `redacted` in the alternation. Python's `re` engine
  matches left-to-right and takes the first match, so `re` would consume the start of `"redacted"` and leave `"dacted"` as a false positive.
  - Fixed by sorting alternatives longest-to-shortest so full words like `redacted` match before their prefixes.
  - Added a regression test that demonstrates the old pattern's failure inline, making the bug and the fix easy to verify side-by-side.